### PR TITLE
updating values to be a dynamic set instead of raw yaml

### DIFF
--- a/examples/external-dns/main.tf
+++ b/examples/external-dns/main.tf
@@ -84,7 +84,7 @@ module "external_dns" {
   dns_provider     = "aws"
   route53_zone_arn = data.aws_route53_zone.selected.arn
   values = {
-    "aws.zone" : "public",
+    "aws.zoneType" : "public",
     "txtOwnerId" : local.cluster_name,
     "domainFilters[0]" : var.public_dns_domain
   }

--- a/examples/external-dns/main.tf
+++ b/examples/external-dns/main.tf
@@ -83,7 +83,7 @@ module "external_dns" {
   tenant_name      = var.tenant_name
   dns_provider     = "aws"
   route53_zone_arn = data.aws_route53_zone.selected.arn
-  values = {
+  sets = {
     "aws.zoneType" : "public",
     "txtOwnerId" : local.cluster_name,
     "domainFilters[0]" : var.public_dns_domain

--- a/modules/external-dns/main.tf
+++ b/modules/external-dns/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "external-dns" {
   namespace  = local.namespace
   values = [
     yamlencode(local.values),
-    var.values
+    yamlencode(var.values)
   ]
 
   dynamic "set" {

--- a/modules/external-dns/main.tf
+++ b/modules/external-dns/main.tf
@@ -18,11 +18,12 @@ resource "helm_release" "external-dns" {
   version    = var.chart_version
   namespace  = local.namespace
   values = [
-    yamlencode(local.values)
+    yamlencode(local.values),
+    yamlencode(var.values)
   ]
 
   dynamic "set" {
-    for_each = var.values
+    for_each = var.sets
     content {
       name  = set.key
       value = set.value

--- a/modules/external-dns/main.tf
+++ b/modules/external-dns/main.tf
@@ -19,7 +19,7 @@ resource "helm_release" "external-dns" {
   namespace  = local.namespace
   values = [
     yamlencode(local.values),
-    yamlencode(var.values)
+    var.values
   ]
 
   dynamic "set" {

--- a/modules/external-dns/main.tf
+++ b/modules/external-dns/main.tf
@@ -18,7 +18,14 @@ resource "helm_release" "external-dns" {
   version    = var.chart_version
   namespace  = local.namespace
   values = [
-    yamlencode(local.values),
-    yamlencode(var.values)
+    yamlencode(local.values)
   ]
+
+  dynamic "set" {
+    for_each = var.values
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 }

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -12,7 +12,7 @@ variable "chart_version" {
 variable "values" {
   description = "Additional raw yaml values to pass to the Helm chart"
   type        = list(string)
-  default     = []
+  default     = [""]
 }
 
 variable "service_account" {

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -12,7 +12,7 @@ variable "chart_version" {
 variable "values" {
   description = "Additional raw yaml values to pass to the Helm chart"
   type        = list
-  default     = []
+  default     = null
 }
 
 variable "service_account" {

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -11,8 +11,8 @@ variable "chart_version" {
 
 variable "values" {
   description = "Additional raw yaml values to pass to the Helm chart"
-  type        = list(string)
-  default     = [""]
+  type        = list
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -10,7 +10,7 @@ variable "chart_version" {
 }
 
 variable "values" {
-  description = "Additional raw values to pass to the Helm chart"
+  description = "Additional raw yaml values to pass to the Helm chart"
   type        = list(string)
   default     = []
 }
@@ -34,7 +34,7 @@ variable "route53_zone_arn" {
 }
 
 variable "sets" {
-  description = "Additional Helm set values to pass to the Helm, using dotted notation"
+  description = "Additional Helm values to pass to the Helm chart"
   type        = map(any)
   default     = {}
 }

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -11,7 +11,7 @@ variable "chart_version" {
 
 variable "values" {
   description = "Additional raw yaml values to pass to the Helm chart"
-  type        = list
+  type        = list(string)
   default     = null
 }
 

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -10,9 +10,9 @@ variable "chart_version" {
 }
 
 variable "values" {
-  description = "Additional values to pass to the Helm chart"
-  type        = map(any)
-  default     = {}
+  description = "Additional raw values to pass to the Helm chart"
+  type        = list(string)
+  default     = []
 }
 
 variable "service_account" {
@@ -31,5 +31,10 @@ variable "route53_zone_arn" {
   description = "The ARN of the Route53 zone to manage (AWS only)"
   type        = string
   default     = null
+}
 
+variable "sets" {
+  description = "Additional Helm set values to pass to the Helm, using dotted notation"
+  type        = map(any)
+  default     = {}
 }


### PR DESCRIPTION
## **User description**
Helm provider expects "values" to be yaml.  We support passing "values" as a map. This doesn't work well with yaml dictionaries, which are nested.  This PR converts the user-provided values variable from "values" to a dynamic "set" block, since set supports dotted notation for nested configuration (https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#example-usage---chart-repository) 

After discussing several options with @adam-duplocloud , I believe this method to be the best tradeoff between clarity, usability, and complexity.  I would definitely accept the feedback that the "values" variable should be renamed; my thinking was that it was the clearest name for a concept users of Helm are familiar with.  We also discussed putting the onus of passing well-formed yaml to the user, but I just couldn't ignore the allure of the set dotted notation.


___

## **Type**
enhancement


___

## **Description**
- Changed "aws.zone" to "aws.zoneType" in the `examples/external-dns/main.tf` for better clarity and consistency.
- Removed the direct yamlencode of `var.values` in the Helm release values within `modules/external-dns/main.tf`.
- Introduced a dynamic "set" block for `var.values` to support dotted notation for nested configuration, enhancing the flexibility and usability of Helm chart configurations.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Refine AWS Zone Configuration in External DNS Example</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/external-dns/main.tf

<li>Changed "aws.zone" to "aws.zoneType" in the values map for better <br>clarity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-kubernetes-addons/pull/3/files#diff-fc060d22b40a7937c0d932c97feaa3fb3fd6d3e6f629efb650820e385c8a6412">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Implement Dynamic Set for Helm Release Values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
modules/external-dns/main.tf

<li>Removed direct yamlencode of var.values in Helm release values.<br> <li> Introduced dynamic "set" block for var.values to support dotted <br>notation for nested configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-kubernetes-addons/pull/3/files#diff-98ce19adc0a1277d32be38b5b7f2e08f83d4f9f6eb100990dbe89d7431ad36fa">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

