### PR TITLE
adding support for system ns, sets

### DIFF
--- a/modules/keda/README.md
+++ b/modules/keda/README.md
@@ -1,6 +1,6 @@
 # KEDA 
 
-Uses helm and terraform to install the keda operator into a duplo tenant. 
+Uses helm and terraform to install the keda operator into a duplo tenant. Install to a shared namespace, like a devops tenant or kube-system.
 
 ## References  
   - [keda.sh](https://keda.sh/)

--- a/modules/keda/values.yaml
+++ b/modules/keda/values.yaml
@@ -1,2 +1,0 @@
-nodeSelector:
-  tenantname: ${namespace}

--- a/modules/keda/variables.tf
+++ b/modules/keda/variables.tf
@@ -24,6 +24,6 @@ variable "namespace" {
 
 variable "sets" {
   description = "Additional Helm sets to pass to the keda helm chart"
-  type        = map(any)
+  type        = map(string)
   default     = {}
 }

--- a/modules/keda/variables.tf
+++ b/modules/keda/variables.tf
@@ -1,6 +1,7 @@
 variable "tenant_name" {
   description = "The name of the tenant"
   type        = string
+  default     = null
 }
 
 variable "chart_version" {
@@ -11,6 +12,18 @@ variable "chart_version" {
 
 variable "values" {
   description = "Additional values to pass to the Cert Manager Helm chart"
+  type        = map(any)
+  default     = {}
+}
+
+variable "namespace" {
+  description = "The namespace to install in, defaults to tenant namespace. NOTE: only one KEDA install per cluster is supported!"
+  type        = string
+  default     = null
+}
+
+variable "sets" {
+  description = "Additional Helm sets to pass to the keda helm chart"
   type        = map(any)
   default     = {}
 }

--- a/modules/keda/versions.tf
+++ b/modules/keda/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.11.0"
+      version = ">= 2.11.0"
     }
   }
 }


### PR DESCRIPTION
- Added support for installing to user-provided namespace like kube-system
- Added support for passing in configuration in sets using convenient dotted notation
- Removed values file with single templated value, instead used set

If user passes a namespace, it is used explicitly, otherwise uses tenant namespace.  If user passes a non-tenant namespace, nodeselector is omitted.


```
module "kedacore" {
  #source      = "github.com/duplocloud/terraform-kubernetes-addons//modules/keda?ref=v0.0.2"
  source      = "../../../duplocloud/terraform-kubernetes-addons/modules/keda/"
  namespace   = "kube-system"
}
```

yields


 ```
# module.kedacore.helm_release.kedacore will be created
  + resource "helm_release" "kedacore" {
      + atomic                     = false
      + chart                      = "keda"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + manifest                   = (known after apply)
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "keda"
      + namespace                  = "kube-system"
      + pass_credentials           = false
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://kedacore.github.io/charts"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + values                     = [
          + jsonencode({}),
        ]
      + verify                     = false
      + version                    = "2.12.0"
      + wait                       = true
      + wait_for_jobs              = false
    }
```
while
    
  ```
 module "kedacore" {
  #source      = "github.com/duplocloud/terraform-kubernetes-addons//modules/keda?ref=v0.0.2"
  source      = "../../../duplocloud/terraform-kubernetes-addons/modules/keda/"
  tenant_name = "dev01"
}
```
yeilds

```
  # module.kedacore.helm_release.kedacore will be created
  + resource "helm_release" "kedacore" {
      + atomic                     = false
      + chart                      = "keda"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + manifest                   = (known after apply)
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "keda"
      + namespace                  = "duploservices-dev01"
      + pass_credentials           = false
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://kedacore.github.io/charts"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + values                     = [
          + jsonencode({}),
        ]
      + verify                     = false
      + version                    = "2.12.0"
      + wait                       = true
      + wait_for_jobs              = false

      + set {
          + name  = "nodeSelector.tenantname"
          + value = "duploservices-dev01"
        }
    }
```